### PR TITLE
feat: fall back to profile name for empty {REMIT}

### DIFF
--- a/backend/internal/engine/policy.go
+++ b/backend/internal/engine/policy.go
@@ -177,6 +177,8 @@ func renderPolicy(ctx context.Context, profile *store.AgentProfile, guid string)
 	if profile != nil && profile.Enabled {
 		if r := strings.TrimSpace(profile.Remit); r != "" {
 			remit = wrap(r, guid)
+		} else if n := strings.TrimSpace(profile.Name); n != "" {
+			remit = wrap(n, guid)
 		}
 		m0Entries = decodeOrWarn(ctx, "m0_entries", profile.ID, profile.M0Entries)
 		m3Entries = decodeOrWarn(ctx, "m3_entries", profile.ID, profile.M3Entries)

--- a/backend/internal/engine/policy_test.go
+++ b/backend/internal/engine/policy_test.go
@@ -57,6 +57,22 @@ func TestRenderPolicyDisabledProfile(t *testing.T) {
 	}
 }
 
+func TestRenderPolicyNameFallback(t *testing.T) {
+	p := &store.AgentProfile{
+		Enabled: true,
+		Name:    "support-bot",
+		Remit:   "",
+	}
+	got := renderPolicy(context.Background(), p, "G")
+	wantRemit := `<adrian-untrusted id="G">support-bot</adrian-untrusted id="G">`
+	if !strings.Contains(got, wantRemit) {
+		t.Errorf("expected name to fall in for empty remit, wrapped %q; got:\n%s", wantRemit, got)
+	}
+	if strings.Contains(got, genericRemit) {
+		t.Errorf("generic remit leaked when name fallback should have applied")
+	}
+}
+
 func TestRenderPolicyWithProfile(t *testing.T) {
 	p := &store.AgentProfile{
 		Enabled:   true,


### PR DESCRIPTION
When no default policy is available for an agent, fall back to the mandatory name that it was given e.g. Custom Support Bot