### PR TITLE
feat: group /agents by configured agent profile

### DIFF
--- a/backend/internal/api/handlers_agents.go
+++ b/backend/internal/api/handlers_agents.go
@@ -13,12 +13,14 @@ import (
 )
 
 type agentEntry struct {
-	ID         string `json:"id"`
-	AgentID    string `json:"agent_id"`
-	FirstSeen  string `json:"first_seen"`
-	LastSeen   string `json:"last_seen"`
-	EventCount int    `json:"event_count"`
-	WorstMAD   string `json:"worst_mad"`
+	ID               string `json:"id"`
+	AgentID          string `json:"agent_id"`
+	AgentProfileID   string `json:"agent_profile_id"`
+	AgentProfileName string `json:"agent_profile_name"`
+	FirstSeen        string `json:"first_seen"`
+	LastSeen         string `json:"last_seen"`
+	EventCount       int    `json:"event_count"`
+	WorstMAD         string `json:"worst_mad"`
 }
 
 type agentListResponse struct {
@@ -87,11 +89,13 @@ func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 
 func agentRowToEntry(row *store.AgentRow) agentEntry {
 	return agentEntry{
-		ID:         row.ID,
-		AgentID:    row.AgentID,
-		FirstSeen:  row.FirstSeen.UTC().Format("2006-01-02T15:04:05.000Z"),
-		LastSeen:   row.LastSeen.UTC().Format("2006-01-02T15:04:05.000Z"),
-		EventCount: row.EventCount,
-		WorstMAD:   row.WorstMAD,
+		ID:               row.ID,
+		AgentID:          row.AgentID,
+		AgentProfileID:   row.AgentProfileID,
+		AgentProfileName: row.AgentProfileName,
+		FirstSeen:        row.FirstSeen.UTC().Format("2006-01-02T15:04:05.000Z"),
+		LastSeen:         row.LastSeen.UTC().Format("2006-01-02T15:04:05.000Z"),
+		EventCount:       row.EventCount,
+		WorstMAD:         row.WorstMAD,
 	}
 }

--- a/backend/internal/store/agents.go
+++ b/backend/internal/store/agents.go
@@ -13,13 +13,19 @@ import (
 )
 
 // AgentRow is the read shape used by the runtime agents listing.
+// AgentProfileID / AgentProfileName link the runtime agent (a LangGraph
+// node name like "reason") to the operator-configured agent_profile
+// it most recently produced events under. Empty strings when no event
+// has been produced yet, or when the profile has been deleted.
 type AgentRow struct {
-	ID         string
-	AgentID    string
-	FirstSeen  time.Time
-	LastSeen   time.Time
-	EventCount int
-	WorstMAD   string
+	ID               string
+	AgentID          string
+	AgentProfileID   string
+	AgentProfileName string
+	FirstSeen        time.Time
+	LastSeen         time.Time
+	EventCount       int
+	WorstMAD         string
 }
 
 // AgentSession describes one session an agent has produced events under.
@@ -75,9 +81,26 @@ func (s *Store) ListAgents(ctx context.Context, perPage, offset int) ([]*AgentRo
 		          END, v.created_at DESC
 		          LIMIT 1),
 		         ''
-		     ) AS worst_mad
+		     ) AS worst_mad,
+		     COALESCE(
+		         (SELECT e.agent_profile_id FROM events e
+		          WHERE e.agent_id = a.agent_id AND e.agent_profile_id IS NOT NULL
+		          ORDER BY e.created_at DESC
+		          LIMIT 1),
+		         ''
+		     ) AS agent_profile_id,
+		     COALESCE(
+		         (SELECT ap.name FROM agent_profiles ap
+		          WHERE ap.id = (
+		              SELECT e.agent_profile_id FROM events e
+		              WHERE e.agent_id = a.agent_id AND e.agent_profile_id IS NOT NULL
+		              ORDER BY e.created_at DESC
+		              LIMIT 1
+		          )),
+		         ''
+		     ) AS agent_profile_name
 		 FROM agents a
-		 ORDER BY a.last_seen DESC
+		 ORDER BY agent_profile_name = '' ASC, agent_profile_name ASC, a.last_seen DESC
 		 LIMIT ? OFFSET ?`,
 		perPage, offset)
 	if err != nil {
@@ -89,7 +112,11 @@ func (s *Store) ListAgents(ctx context.Context, perPage, offset int) ([]*AgentRo
 	for rows.Next() {
 		r := &AgentRow{}
 		var firstSeen, lastSeen string
-		if err := rows.Scan(&r.ID, &r.AgentID, &firstSeen, &lastSeen, &r.EventCount, &r.WorstMAD); err != nil {
+		if err := rows.Scan(
+			&r.ID, &r.AgentID, &firstSeen, &lastSeen,
+			&r.EventCount, &r.WorstMAD,
+			&r.AgentProfileID, &r.AgentProfileName,
+		); err != nil {
 			return nil, 0, err
 		}
 		r.FirstSeen = parseTime(firstSeen)
@@ -106,9 +133,29 @@ func (s *Store) GetAgent(ctx context.Context, agentID string) (*AgentRow, []*Age
 	r := &AgentRow{AgentID: agentID}
 	var firstSeen, lastSeen string
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, first_seen, last_seen FROM agents WHERE agent_id = ?`,
+		`SELECT
+		     a.id, a.first_seen, a.last_seen,
+		     COALESCE(
+		         (SELECT e.agent_profile_id FROM events e
+		          WHERE e.agent_id = a.agent_id AND e.agent_profile_id IS NOT NULL
+		          ORDER BY e.created_at DESC
+		          LIMIT 1),
+		         ''
+		     ) AS agent_profile_id,
+		     COALESCE(
+		         (SELECT ap.name FROM agent_profiles ap
+		          WHERE ap.id = (
+		              SELECT e.agent_profile_id FROM events e
+		              WHERE e.agent_id = a.agent_id AND e.agent_profile_id IS NOT NULL
+		              ORDER BY e.created_at DESC
+		              LIMIT 1
+		          )),
+		         ''
+		     ) AS agent_profile_name
+		 FROM agents a
+		 WHERE a.agent_id = ?`,
 		agentID,
-	).Scan(&r.ID, &firstSeen, &lastSeen)
+	).Scan(&r.ID, &firstSeen, &lastSeen, &r.AgentProfileID, &r.AgentProfileName)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil, ErrNotFound

--- a/frontend/app/(dashboard)/agents/page.tsx
+++ b/frontend/app/(dashboard)/agents/page.tsx
@@ -7,8 +7,56 @@ import { Badge } from '@/components/badge'
 import { Pagination } from '@/components/pagination'
 import { madBadgeColor, timeAgo } from '@/lib/utils'
 
+// One row from /api/agents, a runtime LangGraph node observed by the
+// SDK. agent_profile_id + agent_profile_name carry the operator-
+// configured agent profile this node most recently produced events
+// under. Empty string for agents that haven't produced an event yet,
+// or whose profile has been deleted, those group under "Unassigned".
+type AgentRow = {
+  id: string
+  agent_id: string
+  agent_profile_id: string
+  agent_profile_name: string
+  last_seen: string
+  event_count: number
+  worst_mad: string
+}
+
+type AgentGroup = {
+  profile_id: string
+  profile_name: string
+  agents: AgentRow[]
+}
+
+const UNASSIGNED_LABEL = 'Unassigned'
+
+// Group by profile_name preserving the backend's profile-name-then-
+// last_seen ordering. Empty agent_profile_name groups under "Unassigned"
+// at the bottom.
+function group(rows: AgentRow[]): AgentGroup[] {
+  const groups: AgentGroup[] = []
+  const indexByProfile = new Map<string, number>()
+  for (const r of rows) {
+    const key = r.agent_profile_id || ''
+    const name = r.agent_profile_name || UNASSIGNED_LABEL
+    if (!indexByProfile.has(key)) {
+      indexByProfile.set(key, groups.length)
+      groups.push({ profile_id: key, profile_name: name, agents: [] })
+    }
+    groups[indexByProfile.get(key)!].agents.push(r)
+  }
+  // Pin "Unassigned" to the bottom regardless of where it landed in
+  // the source ordering.
+  groups.sort((a, b) => {
+    if (a.profile_name === UNASSIGNED_LABEL) return 1
+    if (b.profile_name === UNASSIGNED_LABEL) return -1
+    return 0
+  })
+  return groups
+}
+
 export default function AgentsPage() {
-  const [data, setData] = useState<{ agents: any[]; total: number }>({ agents: [], total: 0 })
+  const [data, setData] = useState<{ agents: AgentRow[]; total: number }>({ agents: [], total: 0 })
   const [page, setPage] = useState(1)
 
   useEffect(() => {
@@ -17,49 +65,72 @@ export default function AgentsPage() {
       .catch(() => {})
   }, [page])
 
-  const isEmpty = !data.agents.length
+  const isEmpty = !data.agents?.length
+  const groups = group(data.agents || [])
 
   return (
     <div>
-      <h2 className="text-lg font-semibold text-ink mb-6">Agents</h2>
+      <h2 className="text-lg font-semibold text-ink mb-1">Agents</h2>
+      <p className="text-[12.5px] text-ink-3 mb-6">
+        Runtime sub-agents observed by the SDK, grouped under the
+        operator-configured Agent profile (Settings &rarr; Agents).
+      </p>
 
       {isEmpty ? (
         <EmptyState
           title="No agents yet"
-          hint="Agents register the first time your SDK initialises with an API key. Run an instrumented agent and it'll appear here."
+          hint="Sub-agents register the first time your SDK forwards an event under one of your API keys. Run an instrumented agent and it'll appear here."
         />
       ) : (
         <>
-          <div className="bg-surface-raised border border-surface-border rounded-lg overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-ink-3 border-b border-surface-border bg-surface-overlay/50">
-                  <th className="px-4 py-2.5 text-[13px] font-medium">Agent ID</th>
-                  <th className="px-4 py-2.5 text-[13px] font-medium">Last seen</th>
-                  <th className="px-4 py-2.5 text-[13px] font-medium">Events</th>
-                  <th className="px-4 py-2.5 text-[13px] font-medium">Worst MAD</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.agents.map((a: any) => (
-                  <tr key={a.id} className="border-b border-surface-border/50 table-row-hover">
-                    <td className="px-4 py-2.5 font-mono text-xs text-ink-2">
-                      <Link href={`/agents/${a.agent_id}`} className="hover:underline">{a.agent_id}</Link>
-                    </td>
-                    <td className="px-4 py-2.5 text-ink-3 text-xs">{timeAgo(a.last_seen)}</td>
-                    <td className="px-4 py-2.5 text-ink">{a.event_count}</td>
-                    <td className="px-4 py-2.5">
-                      {a.worst_mad && <Badge label={a.worst_mad} className={madBadgeColor(a.worst_mad)} />}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="space-y-6">
+            {groups.map(g => (
+              <AgentGroupCard key={g.profile_id || g.profile_name} group={g} />
+            ))}
           </div>
 
-          <Pagination page={page} perPage={20} total={data.total} onChange={setPage} />
+          <Pagination page={page} perPage={20} total={data.total || 0} onChange={setPage} />
         </>
       )}
+    </div>
+  )
+}
+
+function AgentGroupCard({ group }: { group: AgentGroup }) {
+  const isUnassigned = group.profile_name === UNASSIGNED_LABEL
+  return (
+    <div className="bg-surface-raised border border-surface-border rounded-lg overflow-hidden">
+      <div className="px-5 py-3 border-b border-surface-border bg-surface-overlay/50">
+        <span className={`text-[13px] font-medium ${isUnassigned ? 'text-ink-3 italic' : 'text-ink'}`}>
+          {group.profile_name}
+        </span>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-ink-3 border-b border-surface-border">
+              <th className="px-4 py-2.5 text-[13px] font-medium">Agent</th>
+              <th className="px-4 py-2.5 text-[13px] font-medium">Last seen</th>
+              <th className="px-4 py-2.5 text-[13px] font-medium">Events</th>
+              <th className="px-4 py-2.5 text-[13px] font-medium">Worst MAD</th>
+            </tr>
+          </thead>
+          <tbody>
+            {group.agents.map(a => (
+              <tr key={a.id} className="border-b border-surface-border/50 table-row-hover">
+                <td className="px-4 py-2.5 font-mono text-xs text-ink-2">
+                  <Link href={`/agents/${a.agent_id}`} className="hover:underline">{a.agent_id}</Link>
+                </td>
+                <td className="px-4 py-2.5 text-ink-3 text-xs">{timeAgo(a.last_seen)}</td>
+                <td className="px-4 py-2.5 text-ink">{a.event_count}</td>
+                <td className="px-4 py-2.5">
+                  {a.worst_mad && <Badge label={a.worst_mad} className={madBadgeColor(a.worst_mad)} />}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Adds the following cards to distinguish agents in the Agents tab

<img width="1265" height="683" alt="image" src="https://github.com/user-attachments/assets/5b9e71de-ea6d-4ea8-adb6-01fbec0d58f9" />
