### PR TITLE
Allow backend startup in stub mode

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -64,10 +64,10 @@ func Load() (*Config, error) {
 	}
 	cfg.SlidingWindowTTL = windowTTL
 
-	if cfg.LLMURL == "" || cfg.LLMAPIKey == "" || cfg.LLMModel == "" || cfg.LLMModelPath == "" {
+	if cfg.LLMURL != "" && (cfg.LLMAPIKey == "" || cfg.LLMModel == "" || cfg.LLMModelPath == "") {
 		return nil, errors.New(
-			"ADRIAN_LLM_URL, ADRIAN_LLM_API_KEY, ADRIAN_LLM_MODEL, and " +
-				"ADRIAN_LLM_MODEL_PATH must all be set " +
+			"when ADRIAN_LLM_URL is set, ADRIAN_LLM_API_KEY, ADRIAN_LLM_MODEL, and " +
+				"ADRIAN_LLM_MODEL_PATH must also be set " +
 				"(run `adrian-setup bootstrap --gguf <name>`)",
 		)
 	}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SecureAgentics
+
+package config
+
+import "testing"
+
+func TestLoadAllowsStubModeWithoutLLM(t *testing.T) {
+	t.Setenv("ADRIAN_SESSION_SECRET", "test-secret")
+	t.Setenv("ADRIAN_LLM_URL", "")
+	t.Setenv("ADRIAN_LLM_API_KEY", "")
+	t.Setenv("ADRIAN_LLM_MODEL", "")
+	t.Setenv("ADRIAN_LLM_MODEL_PATH", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+	if cfg.LLMURL != "" {
+		t.Fatalf("LLMURL = %q, want empty for stub mode", cfg.LLMURL)
+	}
+}
+
+func TestLoadRejectsPartialLLMConfig(t *testing.T) {
+	t.Setenv("ADRIAN_SESSION_SECRET", "test-secret")
+	t.Setenv("ADRIAN_LLM_URL", "http://example.test/v1/chat/completions")
+	t.Setenv("ADRIAN_LLM_API_KEY", "")
+	t.Setenv("ADRIAN_LLM_MODEL", "local")
+	t.Setenv("ADRIAN_LLM_MODEL_PATH", "/models/model.gguf")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() error = nil, want validation failure")
+	}
+}


### PR DESCRIPTION
 ## Summary

  Allow the backend to start when `ADRIAN_LLM_URL` is unset, so the existing stub classifier path can be used for local development and no-LLM setups.

  This keeps the current validation for real classifier mode: when `ADRIAN_LLM_URL` is set, the other required LLM environment variables must also be present.

  Closes #6 

  ## Test plan

  - [x] `docker run --rm -v "$PWD":/src -w /src/backend golang:1.25-bookworm go test ./internal/config`

  ## Checklist

  - [ ] CLA signed (see [CLA.md](../CLA.md))
  - [x] Tests pass locally
  - [ ] Docs updated where needed
  - [x] British English; no em-dashes; no marketing fluff
