### PR TITLE
refactor: move stub mode classifier to tests only

### DIFF
--- a/backend/cmd/adrian/main.go
+++ b/backend/cmd/adrian/main.go
@@ -4,8 +4,8 @@
 // Adrian backend entrypoint.
 //
 // Loads config, opens the SQLite database (running idempotent
-// migrations), constructs the API server with the stub classifier,
-// and listens on ADRIAN_BACKEND_PORT until SIGTERM.
+// migrations), constructs the API server with the LLM-backed
+// classifier, and listens on ADRIAN_BACKEND_PORT until SIGTERM.
 package main
 
 import (
@@ -79,18 +79,12 @@ func main() {
 	})
 	go window.Sweep(ctx, 5*time.Minute, windowTTL)
 
-	var classifier engine.Classifier
-	if cfg.LLMURL != "" {
-		classifier = engine.NewHTTPClient(cfg.LLMURL, cfg.LLMAPIKey, cfg.LLMModel, window, st)
-		slog.Info("engine.http_client.wired",
-			"url", cfg.LLMURL, "model", cfg.LLMModel,
-			"window_size", cfg.SlidingWindowSize,
-			"window_ttl_seconds", cfg.SlidingWindowTTL,
-		)
-	} else {
-		classifier = engine.NewStub(cfg.LLMURL, cfg.LLMModelPath)
-		slog.Info("engine.stub.wired", "model_path", cfg.LLMModelPath)
-	}
+	classifier := engine.NewHTTPClient(cfg.LLMURL, cfg.LLMAPIKey, cfg.LLMModel, window, st)
+	slog.Info("engine.http_client.wired",
+		"url", cfg.LLMURL, "model", cfg.LLMModel,
+		"window_size", cfg.SlidingWindowSize,
+		"window_ttl_seconds", cfg.SlidingWindowTTL,
+	)
 
 	// Discord notification dispatcher: a single goroutine consumes
 	// verdicts and fans out to enabled webhooks. The WS handler sends

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -20,9 +20,21 @@ import (
 	"github.com/secureagentics/Adrian/backend/internal/auth"
 	"github.com/secureagentics/Adrian/backend/internal/config"
 	"github.com/secureagentics/Adrian/backend/internal/engine"
+	pb "github.com/secureagentics/Adrian/backend/internal/proto"
 	"github.com/secureagentics/Adrian/backend/internal/store"
 	"github.com/secureagentics/Adrian/backend/internal/ws"
 )
+
+// stubClassifier returns a fixed M0/benign verdict and a no-op Ping.
+// The API tests need a Classifier to construct the server but don't
+// exercise the engine itself.
+type stubClassifier struct{}
+
+func (stubClassifier) Classify(_ context.Context, _ *pb.PairedEvent, _ string) (*engine.Verdict, error) {
+	return &engine.Verdict{MADCode: "M0", Classification: "benign"}, nil
+}
+
+func (stubClassifier) Ping(_ context.Context) error { return nil }
 
 // -----------------------------------------------------------------
 // Readiness
@@ -454,7 +466,7 @@ func newTestServerWithHub(t *testing.T) (*httptest.Server, *sql.DB, *ws.Hub, str
 		t.Fatalf("seed admin: %v", err)
 	}
 	hub := ws.NewHub()
-	srv := httptest.NewServer(api.NewServer(cfg, db, st, engine.NewStub("", ""), hub, ws.NewConnRegistry(), nil))
+	srv := httptest.NewServer(api.NewServer(cfg, db, st, stubClassifier{}, hub, ws.NewConnRegistry(), nil))
 	t.Cleanup(srv.Close)
 	t.Cleanup(func() { _ = db.Close() })
 	cookie := loginAndGetCookie(t, srv, plaintext)
@@ -1080,8 +1092,7 @@ func newTestServerWithMustChange(t *testing.T, mustChange bool) (*httptest.Serve
 	); err != nil {
 		t.Fatalf("seed admin: %v", err)
 	}
-	classifier := engine.NewStub("", "")
-	srv := httptest.NewServer(api.NewServer(cfg, db, st, classifier, ws.NewHub(), ws.NewConnRegistry(), nil))
+	srv := httptest.NewServer(api.NewServer(cfg, db, st, stubClassifier{}, ws.NewHub(), ws.NewConnRegistry(), nil))
 	t.Cleanup(srv.Close)
 	t.Cleanup(func() { _ = db.Close() })
 	return srv, db, plaintext, ""

--- a/backend/internal/engine/engine.go
+++ b/backend/internal/engine/engine.go
@@ -2,14 +2,12 @@
 // Copyright (c) 2026 SecureAgentics
 
 // Package engine is the in-process AI engine that classifies paired
-// SDK events. The skeleton ships a stub that returns a fixed M0
-// verdict; the full implementation builds the prompt, calls
-// ADRIAN_LLM_URL, and parses the M-code response.
+// SDK events. Builds the prompt, calls ADRIAN_LLM_URL, and parses the
+// M-code response.
 package engine
 
 import (
 	"context"
-	"log/slog"
 
 	pb "github.com/secureagentics/Adrian/backend/internal/proto"
 )
@@ -43,31 +41,3 @@ type Classifier interface {
 	// reachable; any error means the upstream is down or wedged.
 	Ping(ctx context.Context) error
 }
-
-// NewStub returns a Classifier that ignores its input and returns a
-// fixed M0 (benign) verdict. Used in tests + as a fall-through when
-// ADRIAN_LLM_URL is not configured.
-func NewStub(llmURL, llmModelPath string) Classifier {
-	return &stub{llmURL: llmURL, llmModelPath: llmModelPath}
-}
-
-type stub struct {
-	llmURL       string
-	llmModelPath string
-}
-
-func (s *stub) Classify(ctx context.Context, _ *pb.PairedEvent, _ string) (*Verdict, error) {
-	slog.InfoContext(ctx, "engine.stub.classify",
-		"llm_url", s.llmURL,
-		"llm_model_path", s.llmModelPath,
-	)
-	return &Verdict{
-		MADCode:        "M0",
-		Classification: "benign",
-		Reasoning:      "stub engine: returns M0 for every input",
-	}, nil
-}
-
-// Ping is a no-op for the stub: the stub IS the upstream and never
-// fails. Real engines round-trip a TCP connection.
-func (s *stub) Ping(_ context.Context) error { return nil }


### PR DESCRIPTION
## Summary
During early development, the stub classifier was created in place of the real one that exists today, this commit moves it to the tests that still need it.

<!-- One or two sentences. What changed and why. -->
The old NewStub and Classify in`engine.go` have been rewritten to be used by the unit tests. 

## Test plan
Ensure unit tests still pass after the move.

## Checklist

- [] CLA signed (see [CLA.md](../CLA.md))
- [x] Tests pass locally
- [x] Docs updated where needed
- [x] British English; no em-dashes; no marketing fluff
