### PR TITLE
fix: use full path to CLA.md instead of relative in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ## Checklist
 
-- [ ] CLA signed (see [CLA.md](../CLA.md))
+- [ ] CLA signed (see [CLA.md](https://github.com/secureagentics/Adrian/blob/main/CLA.md))
 - [ ] Tests pass locally
 - [ ] Docs updated where needed
 - [ ] British English; no em-dashes; no marketing fluff


### PR DESCRIPTION
## Summary
Relative path 404s when the PR template is rendered.

<!-- One or two sentences. What changed and why. -->
../CLA.md -> https://github.com/secureagentics/Adrian/blob/main/CLA.md

## Test plan
Tested in Preview and it renders correctly now.

- [ ]

## Checklist

- [ ] CLA signed (see [CLA.md](../CLA.md))
- [x] Tests pass locally
- [x] Docs updated where needed
- [x] British English; no em-dashes; no marketing fluff
