### PR TITLE
fix(backend/internal/store/webhooks.go): mask only the webhook token …

### DIFF
--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -672,11 +672,8 @@ func TestListAndDeleteWebhooks(t *testing.T) {
 		t.Fatalf("webhooks = %d, want 1", len(hooks))
 	}
 	masked := hooks[0].(map[string]any)["webhook_url_masked"].(string)
-	if !strings.HasPrefix(masked, "https://discord.com/api/webhooks/") {
-		t.Errorf("masked url should keep the discord prefix, got %q", masked)
-	}
-	if strings.Contains(masked, "long-secret-token") {
-		t.Errorf("masked url should not contain the full token, got %q", masked)
+	if masked != "https://discord.com/api/webhooks/999/...***en-12345" {
+		t.Errorf("masked url = %q, want exact token-only masking", masked)
 	}
 
 	// Delete it.

--- a/backend/internal/store/webhooks.go
+++ b/backend/internal/store/webhooks.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -88,12 +89,17 @@ func (s *Store) DeleteWebhook(ctx context.Context, id string) error {
 // re-shows the full URL after the paste-once flow.
 func MaskedURL(u string) string {
 	const visibleSuffix = 8
-	if len(u) <= visibleSuffix+10 {
+	lastSlash := strings.LastIndex(u, "/")
+	if lastSlash == -1 || lastSlash == len(u)-1 {
 		return u
 	}
-	// Keep the host + the leading webhook path, mask the token tail.
+	token := u[lastSlash+1:]
+	if len(token) > visibleSuffix {
+		token = token[len(token)-visibleSuffix:]
+	}
+	// Keep the host + the leading webhook path, mask only the token.
 	// Discord shape: https://discord.com/api/webhooks/<id>/<token>
-	return u[:len(u)-visibleSuffix-12] + "...***" + u[len(u)-visibleSuffix:]
+	return u[:lastSlash+1] + "...***" + token
 }
 
 // ErrInvalidWebhookURL is returned by the handler when the user-supplied


### PR DESCRIPTION
 ## Summary

  Fix Discord webhook masking so `webhook_url_masked` only reveals the webhook
  path plus the intended final token suffix.

  The previous implementation sliced the full URL string, which could expose
  leading characters from the secret token. This change masks only the final
  path segment after the last `/`, and tightens the existing API test to assert
  the expected masked output.
  
  Closes #15 

  ## Test plan

  - [x] `cd backend && go test ./internal/api`
  - [x] Manually verify in Settings -> Discord notifications that a webhook like
  `https://discord.com/api/webhooks/999/long-secret-token-12345` is shown as
  `https://discord.com/api/webhooks/999/...***en-12345`

  ## Checklist

  - [ ] CLA signed (see [CLA.md](https://github.com/secureagentics/Adrian/blob/
  main/CLA.md))
  - [x] Tests pass locally
  - [ ] Docs updated where needed
  - [x] British English; no em-dashes; no marketing fluff