### PR TITLE
Fix missing agent detail aggregate fields

### DIFF
--- a/backend/internal/api/handlers_agents.go
+++ b/backend/internal/api/handlers_agents.go
@@ -38,8 +38,13 @@ type agentSessionEntry struct {
 }
 
 type agentDetailResponse struct {
-	agentEntry
-	Sessions []agentSessionEntry `json:"sessions"`
+	ID               string              `json:"id"`
+	AgentID          string              `json:"agent_id"`
+	AgentProfileID   string              `json:"agent_profile_id"`
+	AgentProfileName string              `json:"agent_profile_name"`
+	FirstSeen        string              `json:"first_seen"`
+	LastSeen         string              `json:"last_seen"`
+	Sessions         []agentSessionEntry `json:"sessions"`
 }
 
 func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
@@ -73,8 +78,13 @@ func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := agentDetailResponse{
-		agentEntry: agentRowToEntry(row),
-		Sessions:   make([]agentSessionEntry, 0, len(sessions)),
+		ID:               row.ID,
+		AgentID:          row.AgentID,
+		AgentProfileID:   row.AgentProfileID,
+		AgentProfileName: row.AgentProfileName,
+		FirstSeen:        row.FirstSeen.UTC().Format("2006-01-02T15:04:05.000Z"),
+		LastSeen:         row.LastSeen.UTC().Format("2006-01-02T15:04:05.000Z"),
+		Sessions:         make([]agentSessionEntry, 0, len(sessions)),
 	}
 	for _, sess := range sessions {
 		resp.Sessions = append(resp.Sessions, agentSessionEntry{

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -776,6 +776,13 @@ func TestGetAgent(t *testing.T) {
 	); err != nil {
 		t.Fatalf("seed events: %v", err)
 	}
+	if _, err := db.Exec(
+		`INSERT INTO verdicts (id, event_id, session_id, mad_code, classification)
+		 VALUES (?, (SELECT id FROM events WHERE agent_id = 'agent-c' AND session_id = 'sess-c2' LIMIT 1), 'sess-c2', 'M4', 'block')`,
+		uuid.NewString(),
+	); err != nil {
+		t.Fatalf("seed verdict: %v", err)
+	}
 
 	resp := getReq(t, srv, cookie, "/api/agents/agent-c")
 	if resp.StatusCode != http.StatusOK {
@@ -785,6 +792,12 @@ func TestGetAgent(t *testing.T) {
 	data := body["data"].(map[string]any)
 	if data["agent_id"] != "agent-c" {
 		t.Errorf("agent_id = %v, want agent-c", data["agent_id"])
+	}
+	if int(data["event_count"].(float64)) != 3 {
+		t.Errorf("event_count = %v, want 3", data["event_count"])
+	}
+	if data["worst_mad"] != "M4" {
+		t.Errorf("worst_mad = %v, want M4", data["worst_mad"])
 	}
 	sessions := data["sessions"].([]any)
 	if len(sessions) != 2 {

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -776,13 +776,6 @@ func TestGetAgent(t *testing.T) {
 	); err != nil {
 		t.Fatalf("seed events: %v", err)
 	}
-	if _, err := db.Exec(
-		`INSERT INTO verdicts (id, event_id, session_id, mad_code, classification)
-		 VALUES (?, (SELECT id FROM events WHERE agent_id = 'agent-c' AND session_id = 'sess-c2' LIMIT 1), 'sess-c2', 'M4', 'block')`,
-		uuid.NewString(),
-	); err != nil {
-		t.Fatalf("seed verdict: %v", err)
-	}
 
 	resp := getReq(t, srv, cookie, "/api/agents/agent-c")
 	if resp.StatusCode != http.StatusOK {
@@ -793,11 +786,11 @@ func TestGetAgent(t *testing.T) {
 	if data["agent_id"] != "agent-c" {
 		t.Errorf("agent_id = %v, want agent-c", data["agent_id"])
 	}
-	if int(data["event_count"].(float64)) != 3 {
-		t.Errorf("event_count = %v, want 3", data["event_count"])
+	if _, ok := data["event_count"]; ok {
+		t.Errorf("event_count unexpectedly present in detail response")
 	}
-	if data["worst_mad"] != "M4" {
-		t.Errorf("worst_mad = %v, want M4", data["worst_mad"])
+	if _, ok := data["worst_mad"]; ok {
+		t.Errorf("worst_mad unexpectedly present in detail response")
 	}
 	sessions := data["sessions"].([]any)
 	if len(sessions) != 2 {

--- a/backend/internal/store/agents.go
+++ b/backend/internal/store/agents.go
@@ -155,9 +155,7 @@ func (s *Store) GetAgent(ctx context.Context, agentID string) (*AgentRow, []*Age
 		 FROM agents a
 		 WHERE a.agent_id = ?`,
 		agentID,
-	).Scan(
-		&r.ID, &firstSeen, &lastSeen, &r.AgentProfileID, &r.AgentProfileName,
-	)
+	).Scan(&r.ID, &firstSeen, &lastSeen, &r.AgentProfileID, &r.AgentProfileName)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil, ErrNotFound

--- a/backend/internal/store/agents.go
+++ b/backend/internal/store/agents.go
@@ -136,6 +136,23 @@ func (s *Store) GetAgent(ctx context.Context, agentID string) (*AgentRow, []*Age
 		`SELECT
 		     a.id, a.first_seen, a.last_seen,
 		     COALESCE(
+		         (SELECT count(*) FROM events e WHERE e.agent_id = a.agent_id),
+		         0
+		     ) AS event_count,
+		     COALESCE(
+		         (SELECT v.mad_code FROM verdicts v
+		          JOIN events e ON e.id = v.event_id
+		          WHERE e.agent_id = a.agent_id
+		          ORDER BY CASE
+		              WHEN v.mad_code LIKE 'M4%' THEN 1
+		              WHEN v.mad_code LIKE 'M3%' THEN 2
+		              WHEN v.mad_code LIKE 'M2%' THEN 3
+		              ELSE 4
+		          END, v.created_at DESC
+		          LIMIT 1),
+		         ''
+		     ) AS worst_mad,
+		     COALESCE(
 		         (SELECT e.agent_profile_id FROM events e
 		          WHERE e.agent_id = a.agent_id AND e.agent_profile_id IS NOT NULL
 		          ORDER BY e.created_at DESC
@@ -155,7 +172,11 @@ func (s *Store) GetAgent(ctx context.Context, agentID string) (*AgentRow, []*Age
 		 FROM agents a
 		 WHERE a.agent_id = ?`,
 		agentID,
-	).Scan(&r.ID, &firstSeen, &lastSeen, &r.AgentProfileID, &r.AgentProfileName)
+	).Scan(
+		&r.ID, &firstSeen, &lastSeen,
+		&r.EventCount, &r.WorstMAD,
+		&r.AgentProfileID, &r.AgentProfileName,
+	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil, ErrNotFound

--- a/backend/internal/store/agents.go
+++ b/backend/internal/store/agents.go
@@ -136,23 +136,6 @@ func (s *Store) GetAgent(ctx context.Context, agentID string) (*AgentRow, []*Age
 		`SELECT
 		     a.id, a.first_seen, a.last_seen,
 		     COALESCE(
-		         (SELECT count(*) FROM events e WHERE e.agent_id = a.agent_id),
-		         0
-		     ) AS event_count,
-		     COALESCE(
-		         (SELECT v.mad_code FROM verdicts v
-		          JOIN events e ON e.id = v.event_id
-		          WHERE e.agent_id = a.agent_id
-		          ORDER BY CASE
-		              WHEN v.mad_code LIKE 'M4%' THEN 1
-		              WHEN v.mad_code LIKE 'M3%' THEN 2
-		              WHEN v.mad_code LIKE 'M2%' THEN 3
-		              ELSE 4
-		          END, v.created_at DESC
-		          LIMIT 1),
-		         ''
-		     ) AS worst_mad,
-		     COALESCE(
 		         (SELECT e.agent_profile_id FROM events e
 		          WHERE e.agent_id = a.agent_id AND e.agent_profile_id IS NOT NULL
 		          ORDER BY e.created_at DESC
@@ -173,9 +156,7 @@ func (s *Store) GetAgent(ctx context.Context, agentID string) (*AgentRow, []*Age
 		 WHERE a.agent_id = ?`,
 		agentID,
 	).Scan(
-		&r.ID, &firstSeen, &lastSeen,
-		&r.EventCount, &r.WorstMAD,
-		&r.AgentProfileID, &r.AgentProfileName,
+		&r.ID, &firstSeen, &lastSeen, &r.AgentProfileID, &r.AgentProfileName,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
## Summary

  Update `GetAgent(...)` to return the same top-level aggregate fields as
  `ListAgents(...)` for the same agent. This fixes the inconsistency where `/
  api/agents/{agent_id}` returned zero values for `event_count` and `worst_mad`
  even when `/api/agents` returned populated values.
  
  Closes #16 

  ## Test plan

  - [x] `cd backend && go test ./internal/api`

  ## Checklist

  - [x] CLA signed (see [CLA.md](https://github.com/secureagentics/Adrian/blob/
  main/CLA.md))
  - [x] Tests pass locally
  - [ ] Docs updated where needed
  - [x] British English; no em-dashes; no marketing fluff