### PR TITLE
fix: Make WebSocket event ingest idempotent

### DIFF
--- a/backend/internal/store/events.go
+++ b/backend/internal/store/events.go
@@ -67,10 +67,11 @@ type EventFilters struct {
 
 // InsertEvent persists one paired event. The payload column holds the
 // full JSON-encoded PairedEvent blob; downstream readers (dashboard,
-// engine) re-decode it as needed.
+// engine) re-decode it as needed. SDK retries can replay the same
+// event_id, so duplicate primary-key inserts are ignored.
 func (s *Store) InsertEvent(ctx context.Context, e *Event) error {
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO events
+		`INSERT OR IGNORE INTO events
 		   (id, session_id, agent_id, agent_profile_id, event_type, run_id, payload, tokens_used)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		e.ID, e.SessionID, e.AgentID, e.AgentProfileID, e.EventType, e.RunID, e.PayloadJSON, e.TokensUsed)

--- a/backend/internal/ws/handler_test.go
+++ b/backend/internal/ws/handler_test.go
@@ -158,6 +158,88 @@ func TestRoundTrip(t *testing.T) {
 		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 }
 
+func TestDuplicateEventRetryKeepsWSOpen(t *testing.T) {
+	db := openInMemoryDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	st := store.New(db)
+	plaintextKey := "adr_local_test_key_retry"
+	keyHash := sha256Hex(plaintextKey)
+	insertAPIKey(t, db, keyHash)
+	if _, err := db.Exec(`UPDATE policies SET mode = 'block' WHERE id = 1`); err != nil {
+		t.Fatalf("set mode=block: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/ws", ws.AuthMiddleware(st)(ws.NewHandler(st, &fakeClassifier{}, ws.NewHub(), nil, nil)))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+	header := http.Header{"Authorization": {"Bearer " + plaintextKey}}
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	if err := writeProto(conn, &bpb.ClientFrame{
+		Frame: &bpb.ClientFrame_Login{Login: &bpb.SessionLogin{
+			SessionId: "retry-sess", SchemaVersion: 2,
+		}},
+	}); err != nil {
+		t.Fatalf("send login: %v", err)
+	}
+	if _, err := readServerFrame(conn); err != nil {
+		t.Fatalf("read login_ack: %v", err)
+	}
+
+	eventID := uuid.NewString()
+	batchFrame := &bpb.ClientFrame{
+		Frame: &bpb.ClientFrame_PairedBatch{PairedBatch: &bpb.PairedEventBatch{
+			Events: []*bpb.PairedEvent{{
+				EventId: eventID, SessionId: "retry-sess",
+				RunId:    "run-retry",
+				PairType: bpb.PairType_PAIR_TYPE_TOOL,
+				Agent:    &bpb.AgentContext{AgentId: "retry-agent"},
+				Data: &bpb.PairedEvent_Tool{Tool: &bpb.ToolPairData{
+					ToolName: "noop", ToolCallId: "tc-retry", Input: "{}", Output: "ok",
+				}},
+			}},
+		}},
+	}
+
+	if err := writeProto(conn, batchFrame); err != nil {
+		t.Fatalf("send first paired_batch: %v", err)
+	}
+	firstVerdict, err := readServerFrame(conn)
+	if err != nil {
+		t.Fatalf("read first verdict: %v", err)
+	}
+	if got := firstVerdict.GetVerdict().GetEventId(); got != eventID {
+		t.Fatalf("first verdict event_id = %q, want %q", got, eventID)
+	}
+
+	if err := writeProto(conn, batchFrame); err != nil {
+		t.Fatalf("send retry paired_batch: %v", err)
+	}
+	retryVerdict, err := readServerFrame(conn)
+	if err != nil {
+		t.Fatalf("read retry verdict after duplicate event insert: %v", err)
+	}
+	if got := retryVerdict.GetVerdict().GetEventId(); got != eventID {
+		t.Fatalf("retry verdict event_id = %q, want %q", got, eventID)
+	}
+
+	var eventRows int
+	if err := db.QueryRow("SELECT count(*) FROM events WHERE id = ?", eventID).Scan(&eventRows); err != nil {
+		t.Fatalf("query events: %v", err)
+	}
+	if eventRows != 1 {
+		t.Fatalf("expected duplicate retry to keep 1 event row, got %d", eventRows)
+	}
+}
+
 // TestAlertModeNoFanOut confirms the mode gate withholds Verdict
 // frames from the SDK in alert mode (dashboard-only). The verdict row
 // is still persisted; only the WS write is suppressed.


### PR DESCRIPTION
## Summary
- Ignore duplicate `event_id` inserts during event ingest so SDK retry frames do not close the WebSocket.
- Add a WebSocket retry regression test that sends the same paired event twice and verifies the connection still receives verdicts.

## Test plan

- [x] `go test ./internal/ws`

## Checklist

- [x] CLA signed (see [CLA.md](https://github.com/secureagentics/Adrian/blob/main/CLA.md))
- [x] Tests pass locally
- [ ] Docs updated where needed
- [x] British English; no em-dashes; no marketing fluff
