### PR TITLE
Fix Auth secure dashboard session cookie

### DIFF
--- a/backend/internal/api/handlers_auth.go
+++ b/backend/internal/api/handlers_auth.go
@@ -163,6 +163,7 @@ func setSessionCookie(w http.ResponseWriter, token string, ttl time.Duration) {
 		Path:     "/",
 		MaxAge:   int(ttl.Seconds()),
 		HttpOnly: true,
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
 }
@@ -174,6 +175,7 @@ func clearSessionCookie(w http.ResponseWriter) {
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
 }

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -133,8 +133,21 @@ func TestLoginHappyPath(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	if cookie := getCookie(resp, "adrian_token"); cookie == "" {
+	cookie := findCookie(resp, "adrian_token")
+	if cookie == nil {
 		t.Fatal("expected adrian_token cookie")
+	}
+	if cookie.Value == "" {
+		t.Fatal("expected adrian_token cookie value")
+	}
+	if !cookie.HttpOnly {
+		t.Error("adrian_token should be HttpOnly")
+	}
+	if !cookie.Secure {
+		t.Error("adrian_token should be Secure")
+	}
+	if cookie.SameSite != http.SameSiteLaxMode {
+		t.Errorf("adrian_token SameSite = %v, want Lax", cookie.SameSite)
 	}
 	body := decodeBody(t, resp)
 	data := body["data"].(map[string]any)
@@ -143,6 +156,36 @@ func TestLoginHappyPath(t *testing.T) {
 	}
 	if mc, _ := data["must_change_password"].(bool); !mc {
 		t.Errorf("must_change_password should be true on fresh user")
+	}
+}
+
+func TestLogoutClearsSecureSessionCookie(t *testing.T) {
+	srv, _, plaintext, _ := newTestServer(t)
+	cookie := loginAndGetCookie(t, srv, plaintext)
+
+	resp := postJSON(t, srv, cookie, "/api/auth/logout", map[string]any{})
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+
+	cleared := findCookie(resp, "adrian_token")
+	if cleared == nil {
+		t.Fatal("expected adrian_token clearing cookie")
+	}
+	if cleared.Value != "" {
+		t.Errorf("clearing cookie value = %q, want empty", cleared.Value)
+	}
+	if cleared.MaxAge >= 0 {
+		t.Errorf("clearing cookie MaxAge = %d, want negative", cleared.MaxAge)
+	}
+	if !cleared.HttpOnly {
+		t.Error("clearing cookie should be HttpOnly")
+	}
+	if !cleared.Secure {
+		t.Error("clearing cookie should be Secure")
+	}
+	if cleared.SameSite != http.SameSiteLaxMode {
+		t.Errorf("clearing cookie SameSite = %v, want Lax", cleared.SameSite)
 	}
 }
 
@@ -1128,12 +1171,20 @@ func loginAndGetCookie(t *testing.T, srv *httptest.Server, plaintext string) str
 }
 
 func getCookie(resp *http.Response, name string) string {
+	c := findCookie(resp, name)
+	if c == nil {
+		return ""
+	}
+	return c.Value
+}
+
+func findCookie(resp *http.Response, name string) *http.Cookie {
 	for _, c := range resp.Cookies() {
 		if c.Name == name {
-			return c.Value
+			return c
 		}
 	}
-	return ""
+	return nil
 }
 
 func postJSON(t *testing.T, srv *httptest.Server, cookie any, path string, body any) *http.Response {


### PR DESCRIPTION
## Summary

Set Secure on the adrian_token cookie when issuing and clearing dashboard sessions so browsers do not send it over non-HTTPS transport.

The clear path mirrors the set-cookie attributes to reliably expire the same cookie scope.

Added login/logout regression assertions for Secure, HttpOnly, and SameSite=Lax cookie attributes.

## Test plan

- [x]

## Checklist

- [ ] CLA signed (see [CLA.md](https://github.com/secureagentics/Adrian/blob/main/CLA.md))
- [ ] Tests pass locally
- [ ] Docs updated where needed
- [ ] British English; no em-dashes; no marketing fluff
