### PR TITLE
Fix(sdk): block/HITL gate fixes for 'create_react_agent' agents

### DIFF
--- a/sdk/adrian/__init__.py
+++ b/sdk/adrian/__init__.py
@@ -74,7 +74,7 @@ from adrian.session_persistence import resolve_session_id
 from adrian.types import ToolCallRecord, VerdictContext
 from adrian.ws import WebSocketClient
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __all__ = [
     "init",
     "shutdown",

--- a/sdk/adrian/__init__.py
+++ b/sdk/adrian/__init__.py
@@ -74,7 +74,7 @@ from adrian.session_persistence import resolve_session_id
 from adrian.types import ToolCallRecord, VerdictContext
 from adrian.ws import WebSocketClient
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __all__ = [
     "init",
     "shutdown",
@@ -763,20 +763,35 @@ def _patch_langgraph() -> None:
 def _extract_tool_calls(
     state: dict[str, Any] | list[BaseMessage],
 ) -> list[dict[str, str]]:
-    """Extract tool_calls from the last AIMessage in ToolNode state.
+    """Extract tool_calls from the ToolNode input.
 
-    LangGraph's ``ToolNode.ainvoke`` accepts two input shapes: a state
-    dict whose ``"messages"`` key holds the message list, or a bare
-    list of messages.  We handle both.
+    ``ToolNode`` is reached with three input shapes:
+    1. a state dict whose ``"messages"`` key holds the message list
+       (hand-built ``StateGraph`` with ``ToolNode`` as a node), or
+    2. a bare list of messages, or
+    3. a single per-tool-call dict ``{"__type", "tool_call", "state"}``
+       — how langgraph-prebuilt / ``create_react_agent`` dispatch each
+       tool call. The id lives at ``input["tool_call"]["id"]``.
+
+    Shape 3 was previously unhandled: the function returned ``[]``, so the
+    block/HITL gate never found a tool_call_id and ran the tool un-gated.
 
     Args:
-        state: The ToolNode input, a state dict with a ``"messages"``
-            key, or a direct list of ``BaseMessage`` instances.
+        state: The ToolNode input (any of the three shapes above).
 
     Returns:
-        List of tool call dicts from the most recent ``AIMessage``, or
-        an empty list when none is found.
+        List of tool call dicts, or an empty list when none is found.
     """
+    # Shape 3: per-tool-call dispatch (create_react_agent / prebuilt ToolNode).
+    if isinstance(state, dict) and "tool_call" in state:
+        tc = state["tool_call"]
+        if isinstance(tc, dict) and tc.get("id"):
+            return [tc]
+        tc_id = getattr(tc, "id", None)
+        if tc_id:
+            return [{"id": tc_id, "name": getattr(tc, "name", ""), "args": getattr(tc, "args", {})}]
+        return []
+
     if isinstance(state, dict):
         messages = list(state.get("messages") or [])  # pyright: ignore[reportUnknownVariableType, reportUnknownArgumentType]
     else:

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "adrian-sdk-oss"
-version = "1.0.1"
+version = "1.0.2"
 description = "Multi-agent security monitoring SDK for LangChain / LangGraph: paired-event capture, real-time classification, and block mode."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "adrian-sdk-oss"
-version = "1.0.0"
+version = "1.0.1"
 description = "Multi-agent security monitoring SDK for LangChain / LangGraph: paired-event capture, real-time classification, and block mode."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/sdk/tests/test_extract_tool_calls.py
+++ b/sdk/tests/test_extract_tool_calls.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 SecureAgentics
+"""Unit tests for ``_extract_tool_calls`` — the function whose missing shape
+handling let block/HITL skip the verdict wait for ``create_react_agent`` agents.
+
+Covers all three ToolNode input shapes. Shape 3 (per-tool-call dispatch) is the
+one that previously returned ``[]`` and silently un-gated the tool.
+"""
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from adrian import _extract_tool_calls
+
+_TC = {"name": "read_file", "args": {"path": "/etc/shadow"}, "id": "call_1", "type": "tool_call"}
+
+
+def test_shape1_state_dict_with_messages() -> None:
+    """Hand-built StateGraph / ToolNode-as-node -> full {messages} state."""
+    state = {"messages": [HumanMessage("hi"), AIMessage(content="", tool_calls=[_TC])]}
+    assert [t["id"] for t in _extract_tool_calls(state)] == ["call_1"]
+
+
+def test_shape2_bare_message_list() -> None:
+    """A bare list of messages."""
+    msgs = [HumanMessage("hi"), AIMessage(content="", tool_calls=[_TC])]
+    assert [t["id"] for t in _extract_tool_calls(msgs)] == ["call_1"]
+
+
+def test_shape3_per_tool_call_dict() -> None:
+    """create_react_agent / prebuilt per-tool-call dispatch (the regression)."""
+    state = {"__type": "tool_call", "tool_call": _TC, "state": {"messages": []}}
+    # Pre-fix this returned [] -> no tool_call_id -> gate skipped -> tool ran.
+    assert [t["id"] for t in _extract_tool_calls(state)] == ["call_1"]
+
+
+def test_no_tool_calls_returns_empty() -> None:
+    assert _extract_tool_calls({"messages": [HumanMessage("hi")]}) == []
+    assert _extract_tool_calls({"__type": "tool_call", "tool_call": {"name": "x"}, "state": {}}) == []

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "adrian-sdk-oss"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "adrian-sdk-oss"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
 ## Summary
  
  Block mode (and HITL) silently failed to stop tools for agents built with `create_react_agent`: the tool ran before the verdict came back. The gate waits on a `tool_call_id` from `_extract_tool_calls`, which only handled two ToolNode input shapes (full `{"messages": ...}` state, and a bare message list). `create_react_agent` dispatches per tool call in a third shape (`{"__type", "tool_call", "state"}`), so the extractor returned `[]`, the gate got no `tool_call_id`, and ran the tool un-gated in both block and HITL mode.
  
  ## Fix
  
  `sdk/adrian/__init__.py`, `_extract_tool_calls` now handles the per-tool-call `{tool_call}` shape (reads `input["tool_call"]["id"]`). The two existing shapes are untouched. Adds `tests/test_extract_tool_calls.py` covering all three shapes plus the empty case; the third shape fails without this fix.
  
  ## Checklist
  
  - [ ] CLA signed (see [CLA.md](https://github.com/secureagentics/Adrian/blob/main/CLA.md))
  - [x] Tests pass locally (new file + full suite: 263 passed)
  - [ ] Docs updated where needed
  - [x] British English; no em-dashes; no marketing fluff
