### PR TITLE
Fix initial WebSocket connect after sync init

### DIFF
--- a/sdk/python/adrian/ws.py
+++ b/sdk/python/adrian/ws.py
@@ -447,6 +447,12 @@ class WebSocketClient:
         if self._connect_task is None or self._connect_task.done():
             self._connect_task = loop.create_task(self.connect())
 
+    def _ensure_connect_task(self) -> None:
+        """Start the initial/reconnect task if none is currently running."""
+        if self._connect_task is None or self._connect_task.done():
+            loop = asyncio.get_running_loop()
+            self._connect_task = loop.create_task(self.connect())
+
     async def connect(self) -> None:
         """Establish the WebSocket with exponential-backoff retry.
 
@@ -581,6 +587,8 @@ class WebSocketClient:
 
         if not self._connected.is_set() or self._replaying:
             self._buffer_frame(frame_bytes)
+            if not self._replaying:
+                self._ensure_connect_task()
             reason = "disconnected" if not self._connected.is_set() else "replaying"
             logger.info(
                 "buffered for replay (session_id=%s, kind=%s, "
@@ -597,6 +605,7 @@ class WebSocketClient:
 
         if ws is None:
             self._buffer_frame(frame_bytes)
+            self._ensure_connect_task()
 
             return
 
@@ -878,10 +887,7 @@ class WebSocketClient:
         if self._closing:
             return
 
-        loop = asyncio.get_running_loop()
-
-        if self._connect_task is None or self._connect_task.done():
-            self._connect_task = loop.create_task(self.connect())
+        self._ensure_connect_task()
 
     async def _fire_on_disconnect(self, reason: str) -> None:
         """Invoke the on_disconnect callback, catching any exception."""

--- a/sdk/python/adrian/ws.py
+++ b/sdk/python/adrian/ws.py
@@ -605,7 +605,8 @@ class WebSocketClient:
 
         if ws is None:
             self._buffer_frame(frame_bytes)
-            self._ensure_connect_task()
+            if not self._connected.is_set():
+                self._ensure_connect_task()
 
             return
 

--- a/sdk/python/tests/test_init.py
+++ b/sdk/python/tests/test_init.py
@@ -1,5 +1,7 @@
 """Tests for adrian.init / shutdown and auto-instrumentation."""
 
+# pyright: reportPrivateUsage=false
+
 from __future__ import annotations
 
 import asyncio
@@ -68,7 +70,7 @@ class TestInit:
 
         assert log.exists()
 
-    async def test_sync_init_first_async_send_starts_connect_task(self) -> None:
+    def test_sync_init_first_async_send_starts_connect_task(self) -> None:
         """First async send should start connect when init() ran without a loop."""
         adrian.init(
             auto_instrument=False,
@@ -93,9 +95,12 @@ class TestInit:
         async def _fake_connect() -> None:
             connect_calls.append(1)
 
-        with patch.object(ws, "connect", _fake_connect):
-            await ws._send_frame(frame)  # pyright: ignore[reportPrivateUsage]
-            await asyncio.sleep(0)
+        async def _send_once() -> None:
+            with patch.object(ws, "connect", _fake_connect):
+                await ws._send_frame(frame)
+                await asyncio.sleep(0)
+
+        asyncio.run(_send_once())
 
         assert connect_calls == [1]
         assert ws._connect_task is not None

--- a/sdk/python/tests/test_init.py
+++ b/sdk/python/tests/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from collections.abc import Iterator
 from pathlib import Path
@@ -10,6 +11,7 @@ from unittest.mock import patch
 import adrian
 import pytest
 from adrian.config import AdrianConfig, get_config, is_initialized
+from adrian.proto import event_pb2 as pb
 from langchain_core.callbacks.manager import CallbackManager
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.runnables.base import Runnable
@@ -65,6 +67,39 @@ class TestInit:
         adrian.init(log_file=str(log), auto_instrument=False)
 
         assert log.exists()
+
+    async def test_sync_init_first_async_send_starts_connect_task(self) -> None:
+        """First async send should start connect when init() ran without a loop."""
+        adrian.init(
+            auto_instrument=False,
+            api_key="k",
+            ws_url="ws://127.0.0.1:9999/ws",
+        )
+
+        ws = adrian._ws_client
+        assert ws is not None
+        assert ws._connect_task is None
+
+        frame = pb.ClientFrame()
+        event = frame.paired_batch.events.add()
+        event.event_id = "evt-1"
+        event.invocation_id = "inv-1"
+        event.session_id = "sess-1"
+        event.pair_type = pb.PAIR_TYPE_TOOL
+        event.tool.tool_name = "demo"
+
+        connect_calls: list[int] = []
+
+        async def _fake_connect() -> None:
+            connect_calls.append(1)
+
+        with patch.object(ws, "connect", _fake_connect):
+            await ws._send_frame(frame)  # pyright: ignore[reportPrivateUsage]
+            await asyncio.sleep(0)
+
+        assert connect_calls == [1]
+        assert ws._connect_task is not None
+        assert len(ws._replay_buffer) == 1
 
 
 class TestShutdown:


### PR DESCRIPTION
## Summary

  Fix the SDK WebSocket startup path when `adrian.init()` runs before an event loop exists. The first async send now starts the initial background connect task instead of buffering frames forever, and a regression test covers the sync-init case.
  
  Solves #41 

  ## Test plan

  - [x] Reproduced the bug locally: sync `adrian.init(...)` left `_connect_task=None`, and first async send only buffered the frame
  - [x] Verified the fix locally with the same startup pattern: first async send now creates the background connect task
  - [x] `sdk/.venv/bin/python -m py_compile sdk/adrian/ws.py sdk/tests/test_init.py`
  - [ ] Full pytest suite pass locally

  ## Checklist

  - [x] CLA signed (see [CLA.md](https://github.com/secureagentics/Adrian/blob/main/CLA.md))
  - [ ] Tests pass locally
  - [ ] Docs updated where needed
  - [x] British English; no em-dashes; no marketing fluff