### PR TITLE
ci(workflows): add TypeScript SDK build/test matrix

### DIFF
--- a/.github/workflows/ts-sdk-ci.yml
+++ b/.github/workflows/ts-sdk-ci.yml
@@ -1,0 +1,43 @@
+# CI for the TypeScript SDK (sdk/typescript).
+#
+# Runs the canonical install + build + test on every supported OS so a
+# platform-incomplete or peer-broken package-lock.json fails CI instead of
+# shipping.
+#
+# # `npm ci` is deliberate (not `npm install`): it refuses to mutate the
+# lockfile and fails fast on any of the above. The OS matrix is what catches
+# a lockfile that only carries one platform's optional native binaries.
+
+name: TS SDK CI
+
+on:
+  pull_request:
+    paths:
+      - "sdk/typescript/**"
+      - ".github/workflows/ts-sdk-ci.yml"
+
+defaults:
+  run:
+    working-directory: sdk/typescript
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+      # Strict, lockfile-faithful install. Fails on peer conflicts, an
+      # out-of-sync lockfile, or missing integrity hashes.
+      - run: npm ci
+      # build runs tsup + tsc; test runs vitest (whose native binding is the
+      # piece that breaks when the lockfile omits this OS's optional binary).
+      - run: npm run build -w @secureagentics/adrian
+      - run: npm run test -w @secureagentics/adrian

--- a/.github/workflows/ts-sdk-ci.yml
+++ b/.github/workflows/ts-sdk-ci.yml
@@ -39,5 +39,6 @@ jobs:
       - run: npm ci
       # build runs tsup + tsc; test runs vitest (whose native binding is the
       # piece that breaks when the lockfile omits this OS's optional binary).
-      - run: npm run build -w @secureagentics/adrian
-      - run: npm run test -w @secureagentics/adrian
+      # No -w: build/test every workspace package (core + openai + future providers).
+      - run: npm run build
+      - run: npm run test


### PR DESCRIPTION
Run `npm ci`, build, and the vitest suite for sdk/typescript on ubuntu, macOS, and Windows whenever the TypeScript SDK changes.

## Summary
<!-- One or two sentences. What changed and why. -->
This PR adds a new ci job for running the test and build across windows, macos and linux platforms

## Test plan
CI succeeds on PR

## Checklist

- [x] CLA signed (see [CLA.md](https://github.com/secureagentics/Adrian/blob/main/CLA.md))
- [x] Tests pass locally
- [x] Docs updated where needed
- [x] British English; no em-dashes; no marketing fluff
