### PR TITLE
cla: sign CLA for Uche Ephraim Buzugbe (@Uchebuzz)

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -56,5 +56,6 @@ To accept this Agreement, open a pull request that adds an entry to the table be
 | Dhrit Timinkumar Patel | @d180 | 2026-05-20 |
 | Adarsh Tiwari | @adarsh9977 | 2026-05-22 |
 | Muhammad usman | @Muhammad-usman92 | 2026-06-11 |
+| Uche Ephraim Buzugbe | @Uchebuzz | 2026-06-26 |
 
 Once a CLA-bot (cla-assistant.io or equivalent) is wired up, this manual table will be replaced by the bot's status check on each pull request. Existing signatures in this table remain valid; the bot reads from a separate signers list.


### PR DESCRIPTION
Signing the Individual Contributor Licence Agreement as required by CONTRIBUTING.md, ahead of my first code contribution (#61).

| Full name | GitHub handle | Date |
|---|---|---|
| Uche Ephraim Buzugbe | @Uchebuzz | 2026-06-26 |