### PR TITLE
docs: sharpen head-term keywords in README subtitle (SEO/GEO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <b>Open-source runtime security monitoring and control for AI agents.</b>
+  <b>The open-source runtime security toolkit for AI agents — monitoring and in-flight control.</b>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## What

Sharpens the README subtitle to carry our primary search terms ("open-source runtime ... security ... for AI agents") more directly. We rank top-3 on DuckDuckGo/Bing for these queries but are buried on Google; on-page exact-match phrasing on our highest-authority indexed asset (this repo) is one lever in a broader SEO/GEO push.

**Change — subtitle line only:**
- before: *Open-source runtime security monitoring and control for AI agents.*
- after: *The open-source runtime security toolkit for AI agents — monitoring and in-flight control.*

("toolkit" is a deliberate long-tail head-term capture — reviewable, swap back if it's off-brand.)

## Recommended follow-ups (repo settings, not files — need maintainer admin)

Not in this PR because they're metadata, not files. Suggest applying in repo Settings:

1. **About description** →
   `Open-source runtime AI agent security tool. Monitors and controls AI agents — catches malicious tool use, prompt injection, and policy drift in real time, before the agent acts.`
2. **Topics** — add `ai-agents`, `agentic-security`, `self-hosted`.

## Why

Part of the same push that submits Adrian to the awesome-* lists (ProjectRecon, bureado, ottosulin) that Google and LLM answer-engines pull from. No functional change.
