### PR TITLE
Feat/ts reasoning capture

### DIFF
--- a/sdk/typescript/packages/core/src/format/types.ts
+++ b/sdk/typescript/packages/core/src/format/types.ts
@@ -22,6 +22,8 @@ export interface LlmPairData {
   output: string;
   toolCalls: ToolCallRecord[];
   usage: TokenUsage | null;
+  /** The model's reasoning / chain of thought. */
+  reasoning: string;
   error?: ErrorData;
 }
 

--- a/sdk/typescript/packages/core/src/pairing.ts
+++ b/sdk/typescript/packages/core/src/pairing.ts
@@ -80,6 +80,7 @@ export class EventPairBuffer {
         output: endData.output ?? "",
         toolCalls: endData.toolCalls ?? [],
         usage: endData.usage ?? null,
+        reasoning: endData.reasoning ?? "",
         error: endData.error,
       },
       metadata: start.metadata,

--- a/sdk/typescript/packages/core/src/pii/redactor.ts
+++ b/sdk/typescript/packages/core/src/pii/redactor.ts
@@ -23,6 +23,7 @@ export class PiiRedactor {
     if (target.data.kind === "llm") {
       for (const message of target.data.messages) message.content = this.redactString(message.content);
       target.data.output = this.redactString(target.data.output);
+      target.data.reasoning = this.redactString(target.data.reasoning);
       for (const call of target.data.toolCalls) call.args = this.redactValue(call.args) as typeof call.args;
     } else {
       target.data.input = this.redactString(target.data.input);
@@ -51,7 +52,7 @@ export class PiiRedactor {
     const texts = [event.agent.systemPrompt, event.agent.userInstruction];
     if (event.parent) texts.push(event.parent.systemPrompt, event.parent.userInstruction);
     if (event.data.kind === "llm") {
-      texts.push(...event.data.messages.map((msg) => msg.content), event.data.output);
+      texts.push(...event.data.messages.map((msg) => msg.content), event.data.output, event.data.reasoning);
       for (const call of event.data.toolCalls) collectStrings(call.args, texts);
     } else {
       texts.push(event.data.input, event.data.output);

--- a/sdk/typescript/packages/core/src/proto/schema.ts
+++ b/sdk/typescript/packages/core/src/proto/schema.ts
@@ -53,7 +53,14 @@ export type ServerFrame =
   | { loginAck: LoginAck }
   | { verdict: Verdict };
 
-const protoSource = `
+/**
+ * Hand-maintained mirror of proto/event.proto.
+ *
+ * There is no TS codegen step, so this must be updated by hand whenever the
+ * canonical schema changes. `tests/protoDrift.test.ts` parses both and fails
+ * if they disagree.
+ */
+export const protoSource = `
 syntax = "proto3";
 package adrian.core_api.v1;
 enum PairType { PAIR_TYPE_UNSPECIFIED = 0; PAIR_TYPE_LLM = 1; PAIR_TYPE_TOOL = 2; }
@@ -63,19 +70,20 @@ message TokenUsage { int32 prompt_tokens = 1; int32 completion_tokens = 2; int32
 message AgentContext { string agent_id = 1; string system_prompt = 2; string user_instruction = 3; }
 message LlmPairData { string model = 1; repeated ChatMessage messages = 2; string output = 3; repeated ToolCall tool_calls = 4; TokenUsage usage = 5; string reasoning = 6; }
 message ToolPairData { string tool_name = 1; string tool_call_id = 2; string input = 3; string output = 4; }
-message PairedEvent { string event_id = 1; string invocation_id = 2; string session_id = 3; string run_id = 4; string parent_run_id = 5; string timestamp = 6; PairType pair_type = 7; AgentContext agent = 8; AgentContext parent = 9; oneof data { LlmPairData llm = 10; ToolPairData tool = 11; } bytes metadata_json = 20; }
+message PairedEvent { string event_id = 1; string invocation_id = 2; string session_id = 3; string run_id = 4; string parent_run_id = 5; string timestamp = 6; PairType pair_type = 7; AgentContext agent = 8; AgentContext parent = 9; oneof data { LlmPairData llm = 10; ToolPairData tool = 11; } string connection_id = 12; bytes metadata_json = 20; string source = 21; }
 message PairedEventBatch { repeated PairedEvent events = 1; }
 message McpServer { string name = 1; string transport = 2; string endpoint = 3; }
 message McpInventory { repeated McpServer servers = 1; }
 message LLMStack { string provider = 1; string model = 2; }
-message SessionLogin { string session_id = 1; LLMStack llm_stack = 2; reserved 3; uint32 schema_version = 4; }
+message SessionLogin { string session_id = 1; LLMStack llm_stack = 2; reserved 3; uint32 schema_version = 4; string source = 5; string connection_id = 6; }
 message ClientFrame { reserved 2; oneof frame { SessionLogin login = 1; PairedEventBatch paired_batch = 3; McpInventory mcp_inventory = 4; } }
 enum Mode { MODE_UNSPECIFIED = 0; MODE_ALERT = 1; MODE_HITL = 2; MODE_BLOCK = 3; }
-message PolicySnapshot { Mode mode = 1; bool policy_m0 = 2; bool policy_m2 = 3; bool policy_m3 = 4; bool policy_m4 = 5; }
+message PolicySnapshot { Mode mode = 1; bool policy_m0 = 2; bool policy_m2 = 3; bool policy_m3 = 4; bool policy_m4 = 5; bool fail_closed_on_classifier_error = 6; }
 message HitlResponse { bool continue_execution = 1; }
 message LoginAck { PolicySnapshot policy = 1; }
 message ServerFrame { oneof frame { LoginAck login_ack = 1; Verdict verdict = 2; } }
-message Verdict { string event_id = 1; string session_id = 2; reserved 3; string mad_code = 4; reserved 5; PolicySnapshot policy = 6; HitlResponse hitl = 7; }
+enum VerdictStatus { VERDICT_STATUS_UNSPECIFIED = 0; VERDICT_STATUS_OK = 1; VERDICT_STATUS_ERROR = 2; }
+message Verdict { string event_id = 1; string session_id = 2; reserved 3; string mad_code = 4; reserved 5; PolicySnapshot policy = 6; HitlResponse hitl = 7; VerdictStatus status = 8; }
 `;
 
 const root = protobuf.parse(protoSource, { keepCase: true }).root;

--- a/sdk/typescript/packages/core/src/proto/schema.ts
+++ b/sdk/typescript/packages/core/src/proto/schema.ts
@@ -113,6 +113,7 @@ export function pairedEventToProto(event: PairedEvent): Record<string, unknown> 
       model: event.data.model,
       messages: event.data.messages,
       output: event.data.output,
+      reasoning: event.data.reasoning,
       tool_calls: event.data.toolCalls.map((call) => ({ name: call.name, args: JSON.stringify(call.args), id: call.id })),
       usage: event.data.usage ? {
         prompt_tokens: event.data.usage.promptTokens,

--- a/sdk/typescript/packages/core/src/types.ts
+++ b/sdk/typescript/packages/core/src/types.ts
@@ -49,6 +49,8 @@ export interface LlmEndData {
   output: string;
   toolCalls: ToolCallRecord[];
   usage: TokenUsage | null;
+  /** The model's reasoning, where the provider exposes it. */
+  reasoning?: string;
   error?: ErrorData;
 }
 

--- a/sdk/typescript/packages/core/tests/proto.test.ts
+++ b/sdk/typescript/packages/core/tests/proto.test.ts
@@ -19,7 +19,7 @@ it("encodes login and paired event frames", () => {
     pairType: "llm",
     agent: { agentId: "agent", systemPrompt: "", userInstruction: "" },
     parent: null,
-    data: { kind: "llm", model: "ChatOpenAI", messages: [], output: "ok", toolCalls: [], usage: null },
+    data: { kind: "llm", model: "ChatOpenAI", messages: [], output: "ok", toolCalls: [], usage: null, reasoning: "" },
     metadata: null,
   };
   const batch = encodeClientFrame({ pairedBatch: { events: [event] } });

--- a/sdk/typescript/packages/core/tests/protoDrift.test.ts
+++ b/sdk/typescript/packages/core/tests/protoDrift.test.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SecureAgentics
+
+import { readFileSync } from "node:fs";
+import protobuf from "protobufjs";
+import { describe, expect, it } from "vitest";
+import { protoSource } from "../src/proto/schema.js";
+
+// Python and Go bindings are generated from proto/event.proto; the TS SDK
+// instead carries a hand-written copy of the schema, so nothing stops the two
+// drifting apart. A wrong field number would corrupt decoding silently, and a
+// missing field means TS can neither send nor read it. These tests parse both
+// and compare, so any change to the canonical schema fails here until the
+// mirror is updated to match.
+
+const CANONICAL_PATH = new URL("../../../../../proto/event.proto", import.meta.url);
+
+function load(source: string): protobuf.Root {
+  return protobuf.parse(source, { keepCase: true }).root;
+}
+
+/** protobufjs reports fullName dot-prefixed; drop it so keys read naturally. */
+function qualified(name: string): string {
+  return name.replace(/^\./, "");
+}
+
+/** Fully-qualified name -> {field: number} for every message in a root. */
+function messageFields(root: protobuf.Root): Map<string, Map<string, number>> {
+  const out = new Map<string, Map<string, number>>();
+  const walk = (ns: protobuf.NamespaceBase) => {
+    for (const nested of ns.nestedArray) {
+      if (nested instanceof protobuf.Type) {
+        const fields = new Map<string, number>();
+        for (const field of nested.fieldsArray) fields.set(field.name, field.id);
+        out.set(qualified(nested.fullName), fields);
+      }
+      if (nested instanceof protobuf.Namespace) walk(nested);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+/** Fully-qualified name -> {value: number} for every enum in a root. */
+function enumValues(root: protobuf.Root): Map<string, Record<string, number>> {
+  const out = new Map<string, Record<string, number>>();
+  const walk = (ns: protobuf.NamespaceBase) => {
+    for (const nested of ns.nestedArray) {
+      if (nested instanceof protobuf.Enum) out.set(qualified(nested.fullName), nested.values);
+      if (nested instanceof protobuf.Namespace) walk(nested);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+/** Field name -> declared type, for comparing types as well as numbers. */
+function fieldTypes(root: protobuf.Root, fullName: string): Map<string, string> {
+  const type = root.lookupType(fullName);
+  const out = new Map<string, string>();
+  for (const field of type.fieldsArray) {
+    out.set(field.name, `${field.repeated ? "repeated " : ""}${field.type}`);
+  }
+  return out;
+}
+
+describe("TS proto mirror matches proto/event.proto", () => {
+  const canonical = load(readFileSync(CANONICAL_PATH, "utf8"));
+  const mirror = load(protoSource);
+  const canonicalMessages = messageFields(canonical);
+  const mirrorMessages = messageFields(mirror);
+
+  it("parses the canonical schema", () => {
+    // Guards the test itself: a silently-empty parse would pass everything.
+    expect(canonicalMessages.size).toBeGreaterThan(10);
+    expect(canonicalMessages.get("adrian.core_api.v1.TokenUsage")).toEqual(
+      new Map([["prompt_tokens", 1], ["completion_tokens", 2], ["total_tokens", 3]]),
+    );
+  });
+
+  it("declares every message the canonical schema defines", () => {
+    const missing = [...canonicalMessages.keys()].filter((name) => !mirrorMessages.has(name));
+    expect(missing).toEqual([]);
+  });
+
+  it("declares every canonical field, with matching numbers", () => {
+    const problems: string[] = [];
+    for (const [name, canonicalFields] of canonicalMessages) {
+      const mirrored = mirrorMessages.get(name);
+      if (!mirrored) continue; // covered by the message-level test above
+      for (const [field, number] of canonicalFields) {
+        if (!mirrored.has(field)) {
+          problems.push(`${name}.${field}=${number} missing from the mirror`);
+        } else if (mirrored.get(field) !== number) {
+          problems.push(`${name}.${field}: mirror=${mirrored.get(field)} canonical=${number}`);
+        }
+      }
+    }
+    expect(problems).toEqual([]);
+  });
+
+  it("invents no fields the canonical schema does not define", () => {
+    const extra: string[] = [];
+    for (const [name, mirrored] of mirrorMessages) {
+      const canonicalFields = canonicalMessages.get(name);
+      if (!canonicalFields) {
+        extra.push(`${name} is not in the canonical schema`);
+        continue;
+      }
+      for (const field of mirrored.keys()) {
+        if (!canonicalFields.has(field)) extra.push(`${name}.${field}`);
+      }
+    }
+    expect(extra).toEqual([]);
+  });
+
+  it("matches canonical field types", () => {
+    const problems: string[] = [];
+    for (const name of mirrorMessages.keys()) {
+      if (!canonicalMessages.has(name)) continue;
+      const canonicalTypes = fieldTypes(canonical, name);
+      const mirrorTypes = fieldTypes(mirror, name);
+      for (const [field, type] of canonicalTypes) {
+        const mirrored = mirrorTypes.get(field);
+        if (mirrored !== undefined && mirrored !== type) {
+          problems.push(`${name}.${field}: mirror=${mirrored} canonical=${type}`);
+        }
+      }
+    }
+    expect(problems).toEqual([]);
+  });
+
+  it("matches canonical enum values", () => {
+    const canonicalEnums = enumValues(canonical);
+    const mirrorEnums = enumValues(mirror);
+    const problems: string[] = [];
+    for (const [name, values] of canonicalEnums) {
+      const mirrored = mirrorEnums.get(name);
+      if (!mirrored) {
+        problems.push(`${name} missing from the mirror`);
+        continue;
+      }
+      for (const [key, number] of Object.entries(values)) {
+        if (mirrored[key] !== number) {
+          problems.push(`${name}.${key}: mirror=${mirrored[key]} canonical=${number}`);
+        }
+      }
+    }
+    expect(problems).toEqual([]);
+  });
+
+  it("keeps reasoning on field 6 of LlmPairData", () => {
+    // The field this branch added; pinned so a renumber cannot slip through.
+    expect(mirrorMessages.get("adrian.core_api.v1.LlmPairData")?.get("reasoning")).toBe(6);
+    expect(canonicalMessages.get("adrian.core_api.v1.LlmPairData")?.get("reasoning")).toBe(6);
+  });
+});

--- a/sdk/typescript/packages/core/tests/ws.test.ts
+++ b/sdk/typescript/packages/core/tests/ws.test.ts
@@ -126,7 +126,7 @@ function llmEvent(eventId: string): PairedEvent {
     pairType: "llm",
     agent: { agentId: "agent", systemPrompt: "", userInstruction: "" },
     parent: null,
-    data: { kind: "llm", model: "ChatOpenAI", messages: [], output: "", toolCalls: [{ id: "tool-1", name: "search", args: {} }], usage: null },
+    data: { kind: "llm", model: "ChatOpenAI", messages: [], output: "", toolCalls: [{ id: "tool-1", name: "search", args: {} }], usage: null, reasoning: "" },
     metadata: null,
   };
 }

--- a/sdk/typescript/packages/openai/src/index.ts
+++ b/sdk/typescript/packages/openai/src/index.ts
@@ -172,6 +172,7 @@ function instrumentResponses(responses: unknown, options: AdrianOptions): unknow
 /** Aggregate Chat Completions stream chunks into one paired LLM event at the end. */
 function captureChatCompletionStream(model: string, messages: ReturnType<typeof normalizeMessages>, metadata: CallbackMetadata | null, stream: AsyncIterable<unknown>): AsyncIterable<unknown> {
   let output = "";
+  let reasoning = "";
   let usage: LlmEndData["usage"] = null;
   // OpenAI streams tool calls by index; merge partial deltas before emit.
   const toolCallParts = new Map<number, { id: string; name: string; args: string }>();
@@ -182,6 +183,9 @@ function captureChatCompletionStream(model: string, messages: ReturnType<typeof 
     for (const choice of (obj.choices as any[] ?? [])) {
       const delta = choice.delta;
       output += stringifyContent(delta?.content);
+      // OpenAI-compatible servers stream a reasoning model's chain of
+      // thought here; OpenAI itself never sets it.
+      if (typeof delta?.reasoning_content === "string") reasoning += delta.reasoning_content;
 
       for (const call of (delta?.tool_calls ?? [])) {
         const fn = call.function;
@@ -193,13 +197,17 @@ function captureChatCompletionStream(model: string, messages: ReturnType<typeof 
         });
       }
     }
-  }, () => emptyLlmEnd(output, [...toolCallParts.values()].map((call) => ({ id: call.id, name: call.name, args: parseToolArgs(call.args) })), usage), gateLlmEndData);
+  }, () => ({ ...emptyLlmEnd(output, [...toolCallParts.values()].map((call) => ({ id: call.id, name: call.name, args: parseToolArgs(call.args) })), usage), reasoning }), gateLlmEndData);
 }
 
 /** Aggregate Responses API stream events into one paired LLM event at the end. */
 function captureResponseStream(model: string, messages: ReturnType<typeof normalizeMessages>, metadata: CallbackMetadata | null, stream: AsyncIterable<unknown>): AsyncIterable<unknown> {
   let output = "";
   let usage: LlmEndData["usage"] = null;
+  // Reasoning summaries stream as their own delta events, one run per
+  // summary part; parts are joined in the order they complete.
+  const reasoningParts: string[] = [];
+  let reasoningCurrent = "";
 
   const toolCallParts = new Map<string, { id: string; name: string; args: string }>();
 
@@ -214,22 +222,40 @@ function captureResponseStream(model: string, messages: ReturnType<typeof normal
           output += obj.delta;
           break;
 
+        case "response.reasoning_summary_text.delta":
+          reasoningCurrent += typeof obj.delta === "string" ? obj.delta : "";
+          break;
+
+        case "response.reasoning_summary_part.done":
+        case "response.reasoning_summary_text.done":
+          if (reasoningCurrent.length > 0) {
+            reasoningParts.push(reasoningCurrent);
+            reasoningCurrent = "";
+          }
+          break;
+
         case "response.completed":
           usage = normalizeUsage(obj.usage) ?? usage;
           break;
       }
       collectResponseStreamToolCall(obj, toolCallParts);
     },
-    () =>
-      emptyLlmEnd(
-        output,
-        [...toolCallParts.values()].map((call) => ({
-          id: call.id,
-          name: call.name,
-          args: parseToolArgs(call.args),
-        })),
-        usage,
-      ),
+    () => {
+      // A stream cut off mid-part still reports what arrived.
+      const parts = reasoningCurrent.length > 0 ? [...reasoningParts, reasoningCurrent] : reasoningParts;
+      return {
+        ...emptyLlmEnd(
+          output,
+          [...toolCallParts.values()].map((call) => ({
+            id: call.id,
+            name: call.name,
+            args: parseToolArgs(call.args),
+          })),
+          usage,
+        ),
+        reasoning: parts.join("\n\n"),
+      };
+    },
     gateLlmEndData,
   );
 }
@@ -241,11 +267,25 @@ function extractChatCompletion(result: unknown): LlmEndData {
   const message = (obj.choices as Record<string, unknown>[])[0]
     ?.message as Record<string, unknown> | undefined;
 
-  return emptyLlmEnd(
-    stringifyContent(message?.content),
-    normalizeOpenAIToolCalls(message?.tool_calls),
-    normalizeUsage(obj.usage),
-  );
+  return {
+    ...emptyLlmEnd(
+      stringifyContent(message?.content),
+      normalizeOpenAIToolCalls(message?.tool_calls),
+      normalizeUsage(obj.usage),
+    ),
+    // OpenAI itself never sets these on Chat Completions, but
+    // OpenAI-compatible servers (llama.cpp, vLLM) return a reasoning
+    // model's chain of thought here.
+    reasoning: firstString(message?.reasoning_content, message?.reasoning),
+  };
+}
+
+/** First non-empty string among the candidates, else "". */
+function firstString(...candidates: unknown[]): string {
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.length > 0) return candidate;
+  }
+  return "";
 }
 
 /** Map a completed Responses API object into Adrian LLM end data. */
@@ -253,11 +293,42 @@ function extractResponse(result: unknown): LlmEndData {
   if (isAsyncIterable(result)) return emptyLlmEnd();
   const obj = result as Record<string, unknown>;
 
-  return emptyLlmEnd(
-    typeof obj.output_text === "string" ? obj.output_text : stringifyContent(obj.output),
-    normalizeResponseToolCalls(obj.output),
-    normalizeUsage(obj.usage),
-  );
+  return {
+    ...emptyLlmEnd(
+      typeof obj.output_text === "string" ? obj.output_text : stringifyContent(obj.output),
+      normalizeResponseToolCalls(obj.output),
+      normalizeUsage(obj.usage),
+    ),
+    reasoning: extractResponseReasoning(obj.output),
+  };
+}
+
+/**
+ * Collect reasoning summary text from Responses API output items.
+ *
+ * Reasoning items sit alongside the message items in `output` and carry a
+ * `summary` array of `{ type: "summary_text", text }`. `encrypted_content`
+ * is skipped: it is an opaque blob for multi-turn reuse, not readable text.
+ * The summary is empty unless the caller asked for one via
+ * `reasoning: { summary: "auto" }`, and OpenAI gates it on org verification
+ * for the o-series.
+ */
+function extractResponseReasoning(output: unknown): string {
+  if (!Array.isArray(output)) return "";
+  const parts: string[] = [];
+  for (const item of output as Record<string, unknown>[]) {
+    if (!item || item.type !== "reasoning") continue;
+    const summary = item.summary;
+    if (Array.isArray(summary)) {
+      for (const entry of summary as Record<string, unknown>[]) {
+        if (typeof entry?.text === "string" && entry.text.length > 0) parts.push(entry.text);
+      }
+    }
+    // output_version-style single string, and the shape self-hosted
+    // servers emit when they expose reasoning without a summary list.
+    if (typeof item.reasoning === "string" && item.reasoning.length > 0) parts.push(item.reasoning);
+  }
+  return parts.join("\n\n");
 }
 
 /** Normalise Chat Completions `message.tool_calls` into Adrian tool call records. */

--- a/sdk/typescript/packages/openai/tests/openai.test.ts
+++ b/sdk/typescript/packages/openai/tests/openai.test.ts
@@ -614,3 +614,126 @@ describe("OpenAI instrumentation", () => {
     expect(events[0]).toMatchObject({ model: "gpt-4o", output: "hello" });
   });
 });
+
+describe("OpenAI reasoning capture", () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await adrian.shutdown();
+  });
+
+  async function capture(client: unknown, call: (c: any) => Promise<unknown>): Promise<EventData[]> {
+    const events: EventData[] = [];
+    await adrian.init({ handlers: [], sessionId: "sess", wsUrl: null, onEvent: (_t, d) => { events.push(d); } });
+    await call(client);
+    return events;
+  }
+
+  it("collects reasoning summary text from a Responses API call", async () => {
+    const client = adrian.openai({
+      responses: {
+        create: async () => ({
+          output_text: "391",
+          output: [
+            {
+              type: "reasoning",
+              id: "rs_1",
+              summary: [
+                { type: "summary_text", text: "First step." },
+                { type: "summary_text", text: "Second step." },
+              ],
+              encrypted_content: "gAAAA...",
+            },
+            { type: "message", content: [{ type: "output_text", text: "391" }] },
+          ],
+        }),
+      },
+    });
+
+    const events = await capture(client, (c) => c.responses.create({ model: "gpt-5", input: "17*23?" }));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ kind: "llm", output: "391", reasoning: "First step.\n\nSecond step." });
+  });
+
+  it("leaves reasoning empty when only encrypted content is returned", async () => {
+    // o4-mini on an unverified org: reasoning item present, summary empty.
+    const client = adrian.openai({
+      responses: {
+        create: async () => ({
+          output_text: "391",
+          output: [{ type: "reasoning", id: "rs_1", summary: [], content: [], encrypted_content: "gAAAA..." }],
+        }),
+      },
+    });
+
+    const events = await capture(client, (c) => c.responses.create({ model: "o4-mini", input: "17*23?" }));
+
+    expect(events[0]).toMatchObject({ reasoning: "", output: "391" });
+  });
+
+  it("reads reasoning_content from an OpenAI-compatible Chat Completions server", async () => {
+    const client = adrian.openai({
+      chat: {
+        completions: {
+          create: async () => ({
+            choices: [{ message: { content: "391", reasoning_content: "17*20 + 17*3." } }],
+          }),
+        },
+      },
+    });
+
+    const events = await capture(client, (c) => c.chat.completions.create({ model: "gpt-oss-20b", messages: [{ role: "user", content: "17*23?" }] }));
+
+    expect(events[0]).toMatchObject({ output: "391", reasoning: "17*20 + 17*3." });
+  });
+
+  it("has no reasoning for a plain Chat Completions response", async () => {
+    const client = adrian.openai({
+      chat: { completions: { create: async () => ({ choices: [{ message: { content: "391" } }] }) } },
+    });
+
+    const events = await capture(client, (c) => c.chat.completions.create({ model: "gpt-4o-mini", messages: [{ role: "user", content: "17*23?" }] }));
+
+    expect(events[0]).toMatchObject({ output: "391", reasoning: "" });
+  });
+
+  it("accumulates streamed reasoning summary deltas", async () => {
+    const client = adrian.openai({
+      responses: {
+        create: async () => mockOpenAIStream([
+          { type: "response.reasoning_summary_text.delta", delta: "First " },
+          { type: "response.reasoning_summary_text.delta", delta: "step." },
+          { type: "response.reasoning_summary_part.done" },
+          { type: "response.reasoning_summary_text.delta", delta: "Second step." },
+          { type: "response.reasoning_summary_part.done" },
+          { type: "response.output_text.delta", delta: "391" },
+          { type: "response.completed", usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 } },
+        ]),
+      },
+    });
+
+    const events = await capture(client, async (c) => {
+      const stream = await c.responses.create({ model: "gpt-5", input: "17*23?", stream: true });
+      for await (const _ of stream as StreamLike<unknown>) { /* drain */ }
+    });
+
+    expect(events[0]).toMatchObject({ output: "391", reasoning: "First step.\n\nSecond step." });
+  });
+
+  it("keeps reasoning that arrived before a stream was cut off", async () => {
+    const client = adrian.openai({
+      responses: {
+        create: async () => mockOpenAIStream([
+          { type: "response.reasoning_summary_text.delta", delta: "Partial thought" },
+        ]),
+      },
+    });
+
+    const events = await capture(client, async (c) => {
+      const stream = await c.responses.create({ model: "gpt-5", input: "17*23?", stream: true });
+      for await (const _ of stream as StreamLike<unknown>) { /* drain */ }
+    });
+
+    expect(events[0]).toMatchObject({ reasoning: "Partial thought" });
+  });
+});


### PR DESCRIPTION
## Summary

<!-- One or two sentences. What changed and why. -->
Adds reasoning capture support for the TS OpenAI SDK. Also performs a test that will notify us when the protobuf has drifted.

## Test plan

- [x] Tested locally and confirmed working against:

1. gpt-5
2. gpt-5-mini
3. gpt-5-nano
4. gpt-5.4-mini
5. gpt-5.5
6. gpt-5.6-luna

## Checklist

- [x] CLA signed (see [CLA.md](https://github.com/secureagentics/Adrian/blob/main/CLA.md))
- [x] Tests pass locally
- [x] Docs updated where needed
- [x] British English; no em-dashes; no marketing fluff
